### PR TITLE
Ability to not intercept touch events

### DIFF
--- a/telescope/src/main/res/values/attrs.xml
+++ b/telescope/src/main/res/values/attrs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <declare-styleable name="TelescopeLayout">
+    <attr name="interceptTouchEvents" format="boolean"/>
     <attr name="pointerCount" format="integer"/>
     <attr name="progressColor" format="color"/>
     <attr name="screenshot" format="boolean"/>


### PR DESCRIPTION
This PR introduces a new attribute, `interceptTouchEvents`, that can be used to prevent `TelescopeLayout` from consuming touch events.

The default value is `true`, which means that by default `TelescopeLayout` will consume touch events when two fingers are on the screen. So the default behavior hasn't changed.

However, when `interceptTouchEvents` is false, views under `TelescopeLayout` will still receive touch events when two fingers are on the screen. This means that for instance two finger zooming now works, even though Telescope is also going to start in parallel.
