### PR TITLE
Fix disallowIntercept bug with ListView scrolling inside a TelescopeLayout

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/telescope-sample/build.gradle
+++ b/telescope-sample/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.12.2'
+    classpath 'com.android.tools.build:gradle:1.0.0'
   }
 }
 
@@ -15,7 +15,7 @@ dependencies {
 
 android {
   compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  buildToolsVersion "21.1.1"
 
   defaultConfig {
     versionName VERSION_NAME

--- a/telescope-sample/src/main/java/com/mattprecious/telescope/sample/SampleActivity.java
+++ b/telescope-sample/src/main/java/com/mattprecious/telescope/sample/SampleActivity.java
@@ -31,6 +31,7 @@ public class SampleActivity extends Activity {
   private static final int PAGE_THREE_FINGER = 4;
   private static final int PAGE_OTHER_TARGET = 5;
   private static final int PAGE_ADDITIONAL_ATTACHMENT = 6;
+  private static final int PAGE_WITH_LIST_VIEW = 7;
 
   @InjectView(R.id.drawer) DrawerLayout drawerView;
   @InjectView(R.id.drawer_list) ListView drawerListView;
@@ -98,6 +99,14 @@ public class SampleActivity extends Activity {
         break;
       case PAGE_ADDITIONAL_ATTACHMENT:
         view = getLayoutInflater().inflate(R.layout.additional_attachment_view, contentView, false);
+        break;
+      case PAGE_WITH_LIST_VIEW:
+        view = getLayoutInflater().inflate(R.layout.with_list_view, contentView, false);
+        ListView list = (ListView) view.findViewById(R.id.content_list);
+        list.setAdapter(new ArrayAdapter<>(this, R.layout.drawer_item_view, new String[] {
+            "This", "is", "a", "list", "with", "a", "rather", "large", "number", "of", "things",
+            "in", "it"
+        }));
         break;
       default:
         throw new IllegalArgumentException("Unknown position: " + position);

--- a/telescope-sample/src/main/res/layout/with_list_view.xml
+++ b/telescope-sample/src/main/res/layout/with_list_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mattprecious.telescope.sample.ui.SampleEmailView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+  <com.mattprecious.telescope.TelescopeLayout
+      android:id="@+id/telescope"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      >
+    <ListView
+        android:id="@+id/content_list"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="#dddddd"
+        android:choiceMode="singleChoice"
+        android:divider="?android:attr/listDivider"
+        />
+  </com.mattprecious.telescope.TelescopeLayout>
+</com.mattprecious.telescope.sample.ui.SampleEmailView>

--- a/telescope-sample/src/main/res/values/strings.xml
+++ b/telescope-sample/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <item>Three Finger</item>
     <item>Other Target</item>
     <item>Additional Attachment</item>
+    <item>With ListView</item>
   </string-array>
 
   <string name="additional_attachment_description">

--- a/telescope/build.gradle
+++ b/telescope/build.gradle
@@ -2,7 +2,7 @@ import com.android.builder.core.BuilderConstants;
 
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.12.+'
+    classpath 'com.android.tools.build:gradle:1.0.0'
   }
 }
 
@@ -10,7 +10,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 19
-  buildToolsVersion '20.0.0'
+  buildToolsVersion '21.1.1'
 
   defaultConfig {
     versionName VERSION_NAME

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
@@ -226,7 +226,7 @@ public class TelescopeLayout extends FrameLayout {
   }
 
   @Override public boolean onTouchEvent(MotionEvent event) {
-    if (!isEnabled() || disallowIntercept) {
+    if (!isEnabled()) {
       return false;
     }
 


### PR DESCRIPTION
@mattprecious ran into this earlier: if you have a ListView inside a TelescopeLayout, and you scroll that ListView, the disallowIntercept value gets stuck as true and the gesture never gets recognized after that point.

The relevant bit from `requestDisallowInterceptTouchEvent` doc: `This parent must obey this request for the duration of the touch (that is, only clear the flag after this parent has received an up or a cancel).`