### PR TITLE
Bitmap Processor support

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/BitmapProcessorListener.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/BitmapProcessorListener.java
@@ -1,0 +1,17 @@
+package com.mattprecious.telescope;
+
+import android.graphics.Bitmap;
+
+/**
+ * Interface definition for a callback to be invoked when a custom process on the {@link Bitmap}
+ * reference to the original screenshot finishes.
+ */
+public interface BitmapProcessorListener {
+
+    /**
+     * Called when the custom process of the original {@link Bitmap} finishes.
+     *
+     * @param screenshot A new {@link Bitmap} object to use and save.
+     */
+    void onBitmapReady(Bitmap screenshot);
+}

--- a/telescope/src/main/java/com/mattprecious/telescope/EmailLens.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/EmailLens.java
@@ -16,7 +16,7 @@ import java.util.Set;
  *
  * <p>The {@link #getBody()} method can be overridden to pre-populate the body of the email.</p>
  */
-public class EmailLens implements Lens {
+public class EmailLens extends Lens {
   private final Context context;
   private final String subject;
   private final String[] addresses;

--- a/telescope/src/main/java/com/mattprecious/telescope/Lens.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/Lens.java
@@ -1,17 +1,37 @@
 package com.mattprecious.telescope;
 
+import android.graphics.Bitmap;
+
 import java.io.File;
 
 /**
  * Interface definition for a callback to be invoked when a capture is triggered from a
  * {@link TelescopeLayout}.
  */
-public interface Lens {
+public abstract class Lens {
+
   /**
-   * Called when a capture is triggered.
+   * Called when a capture is triggered but not saved to a File yet. This is for processing
+   * {@link Bitmap} object before saving. The default implementation does nothing and just returns
+   * the original Bitmap to the {@link BitmapProcessorListener}
+   *
+   * @param screenshot A reference to the screenshot that was captured. Can be null if screenshots
+   * were disabled.
+   * @param listener {@link BitmapProcessorListener} reference to be used when the possible
+   * processes to the original Bitmap are finished.
+   */
+  public void onCapture(Bitmap screenshot, BitmapProcessorListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("BitmapProcessorListener cannot be null");
+    }
+    listener.onBitmapReady(screenshot);
+  }
+
+  /**
+   * Called when a capture is triggered and saved to a {@link File}.
    *
    * @param screenshot A reference to the screenshot that was captured. Can be null if screenshots
    * were disabled.
    */
-  void onCapture(File screenshot);
+  public abstract void onCapture(File screenshot);
 }

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
@@ -348,10 +348,16 @@ public class TelescopeLayout extends FrameLayout {
           View view = getTargetView();
           view.setDrawingCacheEnabled(true);
           Bitmap screenshot = Bitmap.createBitmap(view.getDrawingCache());
+          if (lens != null) {
+            lens.onCapture(screenshot, new BitmapProcessorListener() {
+              @Override
+              public void onBitmapReady(Bitmap screenshot) {
+                capturing = false;
+                new SaveScreenshotTask(screenshot).execute();
+              }
+            });
+          }
           view.setDrawingCacheEnabled(false);
-
-          capturing = false;
-          new SaveScreenshotTask(screenshot).execute();
         }
       });
     } else {


### PR DESCRIPTION
What I did was to split capturing of the screenshot and saving it. `onCapture` with Bitmap parameter is called first in the Lens. Possible bitmap transformations can be made in that method. After the operation finishes, `onBitmapReady` method of `BitmapProcessorListener` will be called. The default implementation does nothing and just calls `onBitmapReady`.

This processing operation can take long. That's why I did it like this to inform TelescopeLayout to continue the operation when it finishes. While this operation continues, `capturing` is kept `true` and all the screen touch events are ignored.

I don't like introducing new classes into other people's libraries. Sorry about that.

This worked for me for my Google Maps screenshot problem. I opened the PR to discuss it. I also want to create Maps Activity in the sample to demonstrate it.

Thank you for the great library. Thank you for taking time to review this.