### PR TITLE
Fix crash in sample code

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
@@ -568,7 +568,7 @@ public class TelescopeLayout extends FrameLayout {
         final int width = displayMetrics.widthPixels;
         final int height = displayMetrics.heightPixels;
 
-        ImageReader imageReader = ImageReader.newInstance(width, height, PixelFormat.RGBX_8888, 2);
+        ImageReader imageReader = ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 2);
         Surface surface = imageReader.getSurface();
 
         final VirtualDisplay display =


### PR DESCRIPTION
Changed the image format to RGBA_8888 as RGBX format is crashing in
Motorola Nexus 6 running 5.1.1