### PR TITLE
Fail silently if the device lacks an email app.

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/EmailLens.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/EmailLens.java
@@ -1,10 +1,12 @@
 package com.mattprecious.telescope;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.annotation.WorkerThread;
+import android.widget.Toast;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,7 +93,12 @@ public class EmailLens extends Lens {
     }
 
     @Override protected void onPostExecute(Intent intent) {
-      context.startActivity(intent);
+      try {
+        context.startActivity(intent);
+      } catch (ActivityNotFoundException e) {
+        Toast.makeText(context, "\uD83D\uDD2D No email apps installed!", Toast.LENGTH_SHORT)
+            .show();
+      }
     }
   }
 }


### PR DESCRIPTION
Otherwise we suffer surprising application crashes.

    FATAL EXCEPTION: main
    Process: com.publicobject.rounds, PID: 6206
    android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.SEND_MULTIPLE typ=message/rfc822 flg=0x1 clip={message/rfc822 U:content://com.publicobject.rounds.telescope.fileprovider/screenshots/telescope-2016-11-27-122823.png} (has extras) }
       at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1809)
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1523)
       at android.app.Activity.startActivityForResult(Activity.java:4224)
       at android.app.Activity.startActivityForResult(Activity.java:4183)
       at android.app.Activity.startActivity(Activity.java:4507)
       at android.app.Activity.startActivity(Activity.java:4475)
       at com.mattprecious.telescope.EmailLens.onPostExecute(EmailLens.java:94)
       at com.mattprecious.telescope.EmailLens.onPostExecute(EmailLens.java:51)