### PR TITLE
Disallow BitmapProcessorListener implementations

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/BitmapProcessorListener.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/BitmapProcessorListener.java
@@ -7,7 +7,11 @@ import android.support.annotation.Nullable;
  * Interface definition for a callback to be invoked when additional processing on the screenshot
  * has been completed.
  */
-public interface BitmapProcessorListener {
+public abstract class BitmapProcessorListener {
   /** Called when additional processing on the screenshot has been completed. */
-  void onBitmapReady(@Nullable Bitmap screenshot);
+  public abstract void onBitmapReady(@Nullable Bitmap screenshot);
+
+  BitmapProcessorListener() {
+    // No external subclasses.
+  }
 }


### PR DESCRIPTION
This class is public only to allow users to call onBitmapReady.