### PR TITLE
Fix using DateFormat on background thread

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
@@ -542,6 +542,7 @@ public class TelescopeLayout extends FrameLayout {
   private class SaveScreenshotTask extends AsyncTask<Void, Void, File> {
     private final Context context;
     private final Bitmap screenshot;
+    private String fileName;
 
     SaveScreenshotTask(Bitmap screenshot) {
       this.context = getContext();
@@ -550,6 +551,7 @@ public class TelescopeLayout extends FrameLayout {
 
     @Override protected void onPreExecute() {
       saving = true;
+      fileName = SCREENSHOT_FILE_FORMAT.format(new Date());
     }
 
     @Override protected File doInBackground(Void... params) {
@@ -564,7 +566,7 @@ public class TelescopeLayout extends FrameLayout {
         return null;
       }
 
-      File file = new File(screenshotFolder, SCREENSHOT_FILE_FORMAT.format(new Date()));
+      File file = new File(screenshotFolder, fileName);
       FileOutputStream out;
       try {
         out = new FileOutputStream(file);


### PR DESCRIPTION
https://developer.android.com/reference/java/text/SimpleDateFormat.html
>Date formats are not synchronized. It is recommended to create separate format instances for each thread. If multiple threads access a format concurrently, it must be synchronized externally.

This isn’t currently an error because AsyncTask uses a SerialExecutor
by default.
So, close this if it's not worth it.