### PR TITLE
Use application context for MediaProjectionManager to avoid leak

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeLayout.java
@@ -182,7 +182,7 @@ public class TelescopeLayout extends FrameLayout {
       requestCaptureReceiver = null;
     } else {
       projectionManager =
-          (MediaProjectionManager) context.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+          (MediaProjectionManager) context.getApplicationContext().getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
       requestCaptureFilter =
           new IntentFilter(RequestCaptureActivity.getResultBroadcastAction(context));


### PR DESCRIPTION
On Android 10, the context used to retrieve `MediaProjectionManager` is leaked, so the recommended workaround is to use the application context.

https://issuetracker.google.com/issues/139732252