### PR TITLE
Run foreground service while capturing

### DIFF
--- a/telescope/src/main/AndroidManifest.xml
+++ b/telescope/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     android:versionCode="1"
     >
 
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
   <application>
     <activity
         android:name=".RequestCaptureActivity"

--- a/telescope/src/main/AndroidManifest.xml
+++ b/telescope/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
           android:resource="@xml/telescope_file_paths"
           />
     </provider>
+    <service
+        android:name=".TelescopeProjectionService"
+        android:foregroundServiceType="mediaProjection" />
   </application>
 
 </manifest>

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -13,33 +13,33 @@ import static android.os.Build.VERSION_CODES.Q;
 
 @TargetApi(Q)
 public class TelescopeProjectionService extends Service {
-    public static final String NOTIFICATION_CHANNEL_ID = "Telescope Notifications";
-    public static final int SERVICE_ID = NOTIFICATION_CHANNEL_ID.hashCode();
+  public static final String NOTIFICATION_CHANNEL_ID = "Telescope Notifications";
+  public static final int SERVICE_ID = NOTIFICATION_CHANNEL_ID.hashCode();
 
-    @Override public void onCreate() {
-        super.onCreate();
+  @Override public void onCreate() {
+    super.onCreate();
 
-        createNotificationChannel();
-        startForeground(
-                SERVICE_ID,
-                new Notification.Builder(this, NOTIFICATION_CHANNEL_ID).build()
-        );
-    }
+    createNotificationChannel();
+    startForeground(
+        SERVICE_ID,
+        new Notification.Builder(this, NOTIFICATION_CHANNEL_ID).build()
+    );
+  }
 
-    private void createNotificationChannel() {
-        NotificationChannel serviceChannel = new NotificationChannel(
-                NOTIFICATION_CHANNEL_ID,
-                "Telescope",
-                NotificationManager.IMPORTANCE_MIN
-        );
+  private void createNotificationChannel() {
+    NotificationChannel serviceChannel = new NotificationChannel(
+        NOTIFICATION_CHANNEL_ID,
+        "Telescope",
+        NotificationManager.IMPORTANCE_MIN
+    );
 
-        NotificationManager notificationManager = getSystemService(NotificationManager.class);
-        notificationManager.createNotificationChannel(serviceChannel);
-    }
+    NotificationManager notificationManager = getSystemService(NotificationManager.class);
+    notificationManager.createNotificationChannel(serviceChannel);
+  }
 
 
-    @Nullable @Override public IBinder onBind(Intent intent) {
-        return null;
-    }
+  @Nullable @Override public IBinder onBind(Intent intent) {
+    return null;
+  }
 
 }

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -1,15 +1,44 @@
 package com.mattprecious.telescope;
 
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.Nullable;
 
-public class TelescopeProjectionService extends Service {
+import static android.os.Build.VERSION_CODES.Q;
 
-    @Nullable
-    @Override
-    public IBinder onBind(Intent intent) {
+@TargetApi(Q)
+public class TelescopeProjectionService extends Service {
+    public static final String NOTIFICATION_CHANNEL_ID = "Telescope Notifications";
+    public static final int SERVICE_ID = NOTIFICATION_CHANNEL_ID.hashCode();
+
+    @Override public void onCreate() {
+        super.onCreate();
+
+        createNotificationChannel();
+        startForeground(
+                SERVICE_ID,
+                new Notification.Builder(this, NOTIFICATION_CHANNEL_ID).build()
+        );
+    }
+
+    private void createNotificationChannel() {
+        NotificationChannel serviceChannel = new NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                "Telescope Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT
+        );
+
+        NotificationManager notificationManager = getSystemService(NotificationManager.class);
+        notificationManager.createNotificationChannel(serviceChannel);
+    }
+
+
+    @Nullable @Override public IBinder onBind(Intent intent) {
         return null;
     }
 

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -29,7 +29,7 @@ public class TelescopeProjectionService extends Service {
     private void createNotificationChannel() {
         NotificationChannel serviceChannel = new NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
-                "Telescope Service Channel",
+                "Telescope",
                 NotificationManager.IMPORTANCE_DEFAULT
         );
 

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -30,7 +30,7 @@ public class TelescopeProjectionService extends Service {
         NotificationChannel serviceChannel = new NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
                 "Telescope",
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_MIN
         );
 
         NotificationManager notificationManager = getSystemService(NotificationManager.class);

--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -1,0 +1,16 @@
+package com.mattprecious.telescope;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+public class TelescopeProjectionService extends Service {
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/mattprecious/telescope/issues/75
Follow-up to https://github.com/mattprecious/telescope/pull/77

This branch was built on top of https://github.com/mattprecious/telescope/pull/76, to leverage the version bumps and also the crash reproducibility.
Please consider merging that PR (it also means the diff for this one is smaller than it looks).

You can follow the commit history for easier understanding of the changes, but in summary:

* Adds a subclass of `Service`, updates the AndroidManifest to refer to it and adds the `FOREGROUND_SERVICE` permission
* Starts the foreground service (Q and above only) when a request for capture is triggered (posting the notification), and keeps it until the screenshot is saved, stopping it afterwards.

Open question: Since the foreground service requires a notification, and thus a notification channel, I hardcoded some values for simplicity (like notification channel name, service ID, notification ID, and didn't define a notification icon). Is this something users of the library absolutely care about, and if so, would it be worth providing a public API via telescope's configuration methods to define them?

<img src="https://user-images.githubusercontent.com/1541701/66292763-5d2e9700-e8e5-11e9-9a98-ba166be16b55.png" width=260px />
