### PR TITLE
Adhere to the API 34 media projection requirements

### DIFF
--- a/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
+++ b/telescope/src/main/java/com/mattprecious/telescope/TelescopeProjectionService.java
@@ -5,6 +5,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -13,8 +14,13 @@ import static android.os.Build.VERSION_CODES.Q;
 
 @TargetApi(Q)
 public class TelescopeProjectionService extends Service {
+  public static final String EXTRA_DATA = "data";
   public static final String NOTIFICATION_CHANNEL_ID = "Telescope Notifications";
   public static final int SERVICE_ID = NOTIFICATION_CHANNEL_ID.hashCode();
+
+  public static String getStartedBroadcastAction(Context context) {
+    return context.getPackageName() + ".telescope.SERVICE_STARTED";
+  }
 
   @Override public void onCreate() {
     super.onCreate();
@@ -26,6 +32,19 @@ public class TelescopeProjectionService extends Service {
             .setSmallIcon(R.drawable.telescope_service)
             .build()
     );
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (!intent.hasExtra(EXTRA_DATA)) {
+        throw new IllegalArgumentException("Service was started without extra: " + EXTRA_DATA);
+    }
+
+    Intent broadcastIntent = new Intent(getStartedBroadcastAction(this));
+    broadcastIntent.putExtra(EXTRA_DATA, (Intent) intent.getParcelableExtra(EXTRA_DATA));
+    sendBroadcast(broadcastIntent);
+
+    return super.onStartCommand(broadcastIntent, flags, startId);
   }
 
   private void createNotificationChannel() {


### PR DESCRIPTION
There is a strict ordering requirement starting with API 34. A media
projection service cannot be started until after the permission has
been granted. With the service starting being deferred, we can no
longer rely on it being started by the time we start the projection in
the first broadcast receiver and must wait for another broadcast.