### PR TITLE
Use major version only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4.2.0
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17


### PR DESCRIPTION
If you're not pinning to a SHA, there's no reason to use a version triple.