### PR TITLE
Remove obsolete gradle action parameter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,8 +25,6 @@ jobs:
           java-version: 17
 
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-home-cache-cleanup: true
 
       - run: ./gradlew build
 


### PR DESCRIPTION
This is the default behavior now.